### PR TITLE
Home image tweaks

### DIFF
--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -8,7 +8,9 @@ export default function Home() {
                 <h2>We work with children, young people and families.</h2>
                 <h2>Together we can have a bigger impact.</h2>
             </div>
-            <img className="home-image" alt="The SWAN team." src="../../images/content/park1.jpg" />
+            <div className="home-image">
+                <img alt="The SWAN team." src="../../images/content/park1.jpg" />
+            </div>
         </div>
     )
 }

--- a/src/pages/Home/home.css
+++ b/src/pages/Home/home.css
@@ -21,9 +21,8 @@
     text-align: center;
     justify-content: center;
     height: 100%;
-    padding: 10px;
-    padding-top: 0px;
-    padding-bottom: 0px;
+    max-width: max-content;
+    padding: 20px;
     border-right: 5px solid rgb(var(--SWAN-vlight));
 }
 
@@ -40,4 +39,14 @@
     max-width: 100%;
     height: auto;
     border: 5px solid rgb(var(--SWAN-vlight));
+}
+
+@media screen and (max-width: 900px) {
+    .home-content {
+        flex-direction: column;
+    }
+
+    .home-text {
+        border: none;
+    }
 }

--- a/src/pages/Home/home.css
+++ b/src/pages/Home/home.css
@@ -11,6 +11,7 @@
     border-right: none;
     align-items: center;
     justify-content: space-around;
+    overflow: hidden;
 }
 
 .home-text {
@@ -18,16 +19,25 @@
     flex-direction: column;
     flex: 1;
     text-align: center;
+    justify-content: center;
+    height: 100%;
     padding: 10px;
     padding-top: 0px;
     padding-bottom: 0px;
+    border-right: 5px solid rgb(var(--SWAN-vlight));
 }
 
 .home-image {
+    display: flex;
+    justify-content: center;
+    align-items: center;
     flex: 2;
-    width: 40%;
-    height: 100%;
-    object-fit: cover;
-    box-sizing: border-box;
-    border-left: 5px solid rgb(var(--SWAN-vlight));
+    padding: 0px;
+    margin: 0px;
+}
+
+.home-image img {
+    max-width: 100%;
+    height: auto;
+    border: 5px solid rgb(var(--SWAN-vlight));
 }


### PR DESCRIPTION
The image on the home page is now inside a container div. This allows it to maximally fit the parent element while preserving aspect ratio and avoiding parts of the image being cut off.

The home page also now has some minor responsive design, changing the flex-direction of the text and image elements so they are vertically oriented on a viewport less than 900px. This creates a more pleasant appearance on mobile, preventing the image from being too small.